### PR TITLE
[dashboard] Use range slider, other tweaks

### DIFF
--- a/dashboard/app-core.py
+++ b/dashboard/app-core.py
@@ -21,9 +21,10 @@ app_ui = ui.page_sidebar(
         ui.input_slider(
             "mass",
             "Mass",
-            2000,
-            6000,
-            3400,
+            min=2000,
+            max=6000,
+            value=(3250, 4750),
+            step=25,
         ),
         ui.input_checkbox_group(
             "species", "Filter by species", species, selected=species
@@ -46,9 +47,11 @@ app_ui = ui.page_sidebar(
 def server(input: Inputs, output: Outputs, session: Session):
     @reactive.Calc
     def filtered_df() -> pd.DataFrame:
-        filt_df = df[df["Species"].isin(input.species())]
-        filt_df = filt_df.loc[filt_df["Body Mass (g)"] > input.mass()]
-        return filt_df
+        return df[
+            df["Species"].isin(input.species()) &
+            (df["Body Mass (g)"] > input.mass()[0]) &
+            (df["Body Mass (g)"] < input.mass()[1])
+        ]
 
     @render.text
     def adelie_count():

--- a/dashboard/app-core.py
+++ b/dashboard/app-core.py
@@ -41,6 +41,7 @@ app_ui = ui.page_sidebar(
             ui.output_plot("length_depth"),
         ),
     ),
+    class_="bslib-page-dashboard",
 )
 
 

--- a/dashboard/app-core.py
+++ b/dashboard/app-core.py
@@ -29,17 +29,15 @@ app_ui = ui.page_sidebar(
             "species", "Filter by species", species, selected=species
         ),
     ),
-    ui.row(ui.layout_columns(*[make_value_box(penguin) for penguin in species])),
-    ui.row(
-        ui.layout_columns(
-            ui.card(
-                ui.card_header("Summary statistics"),
-                ui.output_data_frame("summary_statistics"),
-            ),
-            ui.card(
-                ui.card_header("Penguin bills"),
-                ui.output_plot("length_depth"),
-            ),
+    ui.layout_columns(*[make_value_box(penguin) for penguin in species]),
+    ui.layout_columns(
+        ui.card(
+            ui.card_header("Summary statistics"),
+            ui.output_data_frame("summary_statistics"),
+        ),
+        ui.card(
+            ui.card_header("Penguin bills"),
+            ui.output_plot("length_depth"),
         ),
     ),
 )


### PR DESCRIPTION
A few small tweaks for the dashboard template:

1. Updates the mass slider to be a range slider so that the filter is for mass between two values. Without this the mass slider is a slightly confusing (is it filtering mass below or above the point? etc).

   While here I simplified the pandas filtering.

2. `ui.row()` isn't needed around `ui.layout_columns()`; the latter replaces the `ui.row(ui.column(), ...)` pattern with a single function.

3. I added `class_="bslib-page-dashboard"` to give this dashboard the full dashboard treatment.

![image](https://github.com/posit-dev/py-shiny-templates/assets/5420529/7e805ae2-682d-4c12-9471-1e97e6b42570)
