### PR TITLE
Dockerize Shiny for Python

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,4 +28,4 @@ jobs:
         with:
           context: ./basic-app
           push: true
-          tags: ${{ github.repository }}:latest
+          tags: ${{ github.repository }}:basic-app

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,13 @@
 name: Publish Docker image to Docker Hub
 
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - dockerize  # Trigger the workflow on push events to the dockerize branch
+  pull_request:
+    branches:
+      - dockerize  # Optionally, trigger the workflow on pull request events targeting the dockerize branch
+  workflow_dispatch:  # Allows manual triggering of the workflow
 
 jobs:
   push_to_registry:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,25 @@
+name: Publish Docker image to Docker Hub
+
+on:
+  workflow_dispatch:
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: ./basic-app
+          push: true
+          tags: ${{ github.repository }}:latest

--- a/basic-app/Dockerfile
+++ b/basic-app/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.9
+
+WORKDIR /code
+
+COPY ./requirements.txt /code/requirements.txt
+
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["shiny", "run", "app-express.py", "--host", "0.0.0.0", "--port", "8080"]

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.9
+
+WORKDIR /code
+
+COPY ./requirements.txt /code/requirements.txt
+
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+
+COPY . .
+
+EXPOSE 8080
+
+CMD ["shiny", "run", "app-express.py", "--host", "0.0.0.0", "--port", "8080"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+
+services:
+  basic-app:
+    build: ./basic-app
+    ports:
+      - "8080:8080"
+  dashboard:
+    build: ./dashboard
+    ports:
+      - "8081:8080"


### PR DESCRIPTION
# Overview

I've added a `docker-compose` at the base directory with Dockerfiles in the subdirectories per app to enable people to run locally with a simple `docker compose up`.

Added a Github Action to push `mattmajestic/py-shiny-templates:basic-app` to DockerHub.  Having this Image makes it available across clouds or a service like `render.com` which I have my deployment below.

[![Docker Image](https://img.shields.io/docker/v/mattmajestic/py-shiny-templates?color=blue&label=mattmajestic/py-shiny-templates&logo=docker&logoColor=white&style=for-the-badge)](https://hub.docker.com/r/mattmajestic/py-shiny-templates)
[![Deployed on Render](https://img.shields.io/badge/deployed%20on-Render-%23735DDF?style=for-the-badge&logo=render&logoColor=white)](https://py-shiny-templates-basic-app.onrender.com/)

I recognize this is a bigger initiative for Docker templates but wanted to give my quick way of deploying Shiny for Python with Docker

## Testing

- [ ] Run `docker compose up`
- [ ] Pull test image from DockerHub with `docker pull mattmajestic/py-shiny-templates:basic-app`
- [ ] Add Github Secret for DockerHub to ensure build