### PR TITLE
feat: Add `template.json` files for all templates

### DIFF
--- a/basic-app-plot/_template.json
+++ b/basic-app-plot/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "basic-app-plot",
+  "id": "basic-app-plot",
   "title": "Basic reactive plot",
   "description": "A basic example of changing a histogram based on a select input control.."
 }

--- a/basic-app-plot/_template.json
+++ b/basic-app-plot/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "basic-app-plot",
+  "title": "Basic reactive plot",
+  "description": "A basic example of changing a histogram based on a select input control.."
+}

--- a/basic-app-plot/_template.json
+++ b/basic-app-plot/_template.json
@@ -1,5 +1,5 @@
 {
   "id": "basic-app-plot",
   "title": "Basic reactive plot",
-  "description": "A basic example of changing a histogram based on a select input control.."
+  "description": "A basic example of changing a histogram based on a select input control."
 }

--- a/basic-app/_template.json
+++ b/basic-app/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "basic-app",
+  "id": "basic-app",
   "title": "A Basic app",
   "description": "A simple Shiny app to get you started quickly."
 }

--- a/basic-app/_template.json
+++ b/basic-app/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "basic-app",
+  "title": "A Basic app",
+  "description": "A simple Shiny app to get you started quickly."
+}

--- a/basic-navigation/_template.json
+++ b/basic-navigation/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "basic-navigation",
+  "title": "Navigating multiple panels",
+  "description": "A basic demonstration of common navigation of multiple panels in Shiny."
+}

--- a/basic-navigation/_template.json
+++ b/basic-navigation/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "basic-navigation",
+  "id": "basic-navigation",
   "title": "Navigating multiple panels",
   "description": "A basic demonstration of common navigation of multiple panels in Shiny."
 }

--- a/basic-sidebar/_template.json
+++ b/basic-sidebar/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "basic-sidebar",
+  "title": "Reactive plot in sidebar",
+  "description": "Place numerous input controls in a sidebar and use them to control a plot in the main panel.."
+}

--- a/basic-sidebar/_template.json
+++ b/basic-sidebar/_template.json
@@ -1,5 +1,5 @@
 {
   "id": "basic-sidebar",
-  "title": "Reactive plot in sidebar",
-  "description": "Place numerous input controls in a sidebar and use them to control a plot in the main panel.."
+  "title": "Reactive plot with a sidebar",
+  "description": "Place numerous input controls in a sidebar and use them to control a plot in the main panel."
 }

--- a/basic-sidebar/_template.json
+++ b/basic-sidebar/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "basic-sidebar",
+  "id": "basic-sidebar",
   "title": "Reactive plot in sidebar",
   "description": "Place numerous input controls in a sidebar and use them to control a plot in the main panel.."
 }

--- a/dashboard-tips/_template.json
+++ b/dashboard-tips/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "dashboard-tips",
+  "title": "Restaurant tips dashboard",
+  "description": "An intermediate dashboard with input filters, value boxes, a plot, and table."
+}

--- a/dashboard-tips/_template.json
+++ b/dashboard-tips/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "dashboard-tips",
+  "id": "dashboard-tips",
   "title": "Restaurant tips dashboard",
   "description": "An intermediate dashboard with input filters, value boxes, a plot, and table."
 }

--- a/dashboard/_template.json
+++ b/dashboard/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "dashboard",
+  "id": "dashboard",
   "title": "Basic dashboard",
   "description": "A basic dashboard with input filters, value boxes, a plot, and table."
 }

--- a/dashboard/_template.json
+++ b/dashboard/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "dashboard",
+  "title": "Basic dashboard",
+  "description": "A basic dashboard with input filters, value boxes, a plot, and table."
+}

--- a/database-explorer/_template.json
+++ b/database-explorer/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "database-explorer",
+  "id": "database-explorer",
   "title": "SQL database explorer",
   "description": "Run queries on an SQL database and view the results in a data grid."
 }

--- a/database-explorer/_template.json
+++ b/database-explorer/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "database-explorer",
+  "title": "SQL database explorer",
+  "description": "Run queries on an SQL database and view the results in a data grid."
+}

--- a/map-distance/_template.json
+++ b/map-distance/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "map-distance",
+  "title": "Location distance calculator",
+  "description": "Run queries on an SQL database and view the results in a data grid."
+}

--- a/map-distance/_template.json
+++ b/map-distance/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "map-distance",
+  "id": "map-distance",
   "title": "Location distance calculator",
   "description": "Run queries on an SQL database and view the results in a data grid."
 }

--- a/model-scoring/_template.json
+++ b/model-scoring/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "model-scoring",
+  "id": "model-scoring",
   "title": "Model scoring",
   "description": "Use a combination of scikit-learn and plotnine to visualize model diagnostics like ROC and precision-recall curves."
 }

--- a/model-scoring/_template.json
+++ b/model-scoring/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "model-scoring",
+  "title": "Model scoring",
+  "description": "Use a combination of scikit-learn and plotnine to visualize model diagnostics like ROC and precision-recall curves."
+}

--- a/monitor-database/_template.json
+++ b/monitor-database/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "monitor-database",
+  "title": "Streaming database updates",
+  "description": "Efficiently monitor a database for updates and visualize the data in real-time."
+}

--- a/monitor-database/_template.json
+++ b/monitor-database/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "monitor-database",
+  "id": "monitor-database",
   "title": "Streaming database updates",
   "description": "Efficiently monitor a database for updates and visualize the data in real-time."
 }

--- a/monitor-file/_template.json
+++ b/monitor-file/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "monitor-file",
+  "id": "monitor-file",
   "title": "Streaming file updates",
   "description": "Efficiently monitor a file for updates and visualize the data in real-time."
 }

--- a/monitor-file/_template.json
+++ b/monitor-file/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "monitor-file",
+  "title": "Streaming file updates",
+  "description": "Efficiently monitor a file for updates and visualize the data in real-time."
+}

--- a/monitor-folder/_template.json
+++ b/monitor-folder/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "monitor-folder",
+  "title": "Streaming folder updates",
+  "description": "Monitor a folder for updates (e.g., adding a new file) and visualize the updates in real-time."
+}

--- a/monitor-folder/_template.json
+++ b/monitor-folder/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "monitor-folder",
+  "id": "monitor-folder",
   "title": "Streaming folder updates",
   "description": "Monitor a folder for updates (e.g., adding a new file) and visualize the updates in real-time."
 }

--- a/nba-dashboard/_template.json
+++ b/nba-dashboard/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "nba-dashboard",
+  "title": "NBA player career comparisons",
+  "description": "Search for NBA players and compare their career statistics."
+}

--- a/nba-dashboard/_template.json
+++ b/nba-dashboard/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "nba-dashboard",
+  "id": "nba-dashboard",
   "title": "NBA player career comparisons",
   "description": "Search for NBA players and compare their career statistics."
 }

--- a/regularization/_template.json
+++ b/regularization/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "regularization",
+  "id": "regularization",
   "title": "Article on regularization in ML",
   "description": "An article on regularization in machine learning and statistics."
 }

--- a/regularization/_template.json
+++ b/regularization/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "regularization",
+  "title": "Article on regularization in ML",
+  "description": "An article on regularization in machine learning and statistics."
+}

--- a/stock-app/_template.json
+++ b/stock-app/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "stock-app",
+  "id": "stock-app",
   "title": "Stock price tracker",
   "description": "A basic stock price tracker app."
 }

--- a/stock-app/_template.json
+++ b/stock-app/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "stock-app",
+  "title": "Stock price tracker",
+  "description": "A basic stock price tracker app."
+}

--- a/survey-wizard/_template.json
+++ b/survey-wizard/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "survey-wizard",
+  "title": "Survey wizard form",
+  "description": "A simple survey wizard that simply writes responses to a file and displays a confirmation message when submitted."
+}

--- a/survey-wizard/_template.json
+++ b/survey-wizard/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "survey-wizard",
+  "id": "survey-wizard",
   "title": "Survey wizard form",
   "description": "A simple survey wizard that simply writes responses to a file and displays a confirmation message when submitted."
 }

--- a/survey/_template.json
+++ b/survey/_template.json
@@ -1,5 +1,5 @@
 {
-  "name": "survey",
+  "id": "survey",
   "title": "Survey form",
   "description": "A simple survey form with a few input fields that simply writes responses to a file and displays a confirmation message when submitted."
 }

--- a/survey/_template.json
+++ b/survey/_template.json
@@ -1,0 +1,5 @@
+{
+  "name": "survey",
+  "title": "Survey form",
+  "description": "A simple survey form with a few input fields that simply writes responses to a file and displays a confirmation message when submitted."
+}


### PR DESCRIPTION
For https://github.com/posit-dev/py-shiny/pull/1631 ~but can be merged at any time~. I'm going to wait to merge this when we also update py-shiny-site or at least closer to the next py-shiny release. The updated `shiny create` workflow removes the `_template.json` files, but they will not be removed by older versions of shiny.

* Related: https://github.com/posit-dev/py-shiny-site/pull/204
* Merge with: https://github.com/posit-dev/py-shiny-site/pull/209

<details><summary>Create template.json</summary>

```r
library(fs)
library(rvest)

apps <- dir_ls(".", recurse = TRUE, glob = "**/app-*.py")
apps <- apps[!grepl("venv", apps)]

for (app in apps) {
  tmpl_json <- path(path_dir(app), "_template.json")
  if (file_exists(tmpl_json)) {
    next
  }

  slug <- path_file(path_dir(app))
  cli::cli_progress_step(slug)
  
  title <- ""
  description <- ""
  tryCatch({
    url <- glue::glue("https://shiny.posit.co/py/templates/{slug}/")
    page <- read_html(url)
  
    title <- page %>% html_node("h1") %>% html_text()
    description <- page %>% html_node(".panel-tabset + p") %>% html_text()
    description <- paste0(strsplit(description, "[.] [A-Z]")[[1]][1], ".")
  }, error = function(err) {
    cli::cli_inform("Failed to scrape template info for {slug}.")
  })

  template <- list(
    name = slug,
    title = title,
    description = description
  )

  jsonlite::write_json(template, tmpl_json, pretty = TRUE, auto_unbox = TRUE)
}

cli::cli_progress_done()
```

</details>