### PR TITLE
Fix(stock-app): Restrict plotly version due to cufflinks incompatibility

### DIFF
--- a/stock-app/requirements.txt
+++ b/stock-app/requirements.txt
@@ -1,5 +1,5 @@
-plotly
-yfinance 
+plotly < 6.0 # https://github.com/santosjorge/cufflinks/issues/289
+yfinance
 pandas==2.2.1
 shiny
 shinywidgets


### PR DESCRIPTION
Related: https://github.com/santosjorge/cufflinks/issues/289