### PR TITLE
fix(dataframe): stop using deprecated row_selection_mode and use selection_mode

### DIFF
--- a/monitor-folder/app-core.py
+++ b/monitor-folder/app-core.py
@@ -33,7 +33,7 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     @render.data_frame
     def file_list():
-        return render.DataGrid(files_df(), row_selection_mode="single")
+        return render.DataGrid(files_df(), selection_mode="row")
 
     @render.ui
     def log_output():

--- a/monitor-folder/app-express.py
+++ b/monitor-folder/app-express.py
@@ -19,7 +19,7 @@ with ui.layout_columns(col_widths=[4, 8]):
 
         @render.data_frame
         def file_list():
-            return render.DataGrid(files_df(), row_selection_mode="single")
+            return render.DataGrid(files_df(), selection_mode="row")
 
     @render.express
     def log_output():


### PR DESCRIPTION
This pull request includes a minor update to the `render.DataGrid` method in both `monitor-folder/app-core.py` and `monitor-folder/app-express.py`. The change standardizes the parameter name for row selection mode.
