### PR TITLE
fix(stocks-app): use curl_cffi to bypass yfinance rate limiting

### DIFF
--- a/stock-app/app-core.py
+++ b/stock-app/app-core.py
@@ -3,10 +3,15 @@ from pathlib import Path
 import cufflinks as cf
 import pandas as pd
 import yfinance as yf
+from curl_cffi import requests
 from faicons import icon_svg
 from shiny import App, Inputs, Outputs, Session, reactive, render, ui
 from shinywidgets import output_widget, render_plotly
 from stocks import stocks
+
+# used to bypass financial APIs that have anti-bot measures in place
+session = requests.Session(impersonate="chrome")
+ticker = yf.Ticker("...", session=session)
 
 # Default to the last 6 months
 end = pd.Timestamp.now()

--- a/stock-app/app-express.py
+++ b/stock-app/app-express.py
@@ -3,12 +3,17 @@ from pathlib import Path
 import cufflinks as cf
 import pandas as pd
 import yfinance as yf
+from curl_cffi import requests
 from faicons import icon_svg
 from shiny import reactive
 from shiny.express import input, render, ui
 from shiny.ui import output_ui
 from shinywidgets import render_plotly
 from stocks import stocks
+
+# used to bypass financial APIs that have anti-bot measures in place
+session = requests.Session(impersonate="chrome")
+ticker = yf.Ticker("...", session=session)
 
 # Default to the last 6 months
 end = pd.Timestamp.now()

--- a/stock-app/requirements.txt
+++ b/stock-app/requirements.txt
@@ -5,4 +5,3 @@ shiny
 shinywidgets
 faicons
 cufflinks
-curl-cffi

--- a/stock-app/requirements.txt
+++ b/stock-app/requirements.txt
@@ -5,3 +5,4 @@ shiny
 shinywidgets
 faicons
 cufflinks
+curl-cffi


### PR DESCRIPTION
This pull request introduces a new dependency, `curl-cffi`, and updates the code in two files to use it for bypassing financial APIs with anti-bot measures. The changes ensure that `yfinance` requests are made using a session that impersonates a browser.
