### PR TITLE
fix(model-scoring): pinning version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - deploy**
+      - fix**
 
 jobs:
   prepare-matrix:

--- a/model-scoring/plots.py
+++ b/model-scoring/plots.py
@@ -33,7 +33,7 @@ def plot_auc_curve(df: DataFrame, true_col: str, pred_col: str):
         + geom_abline(intercept=0, slope=1, color="navy", linetype="dashed")
         + labs(
             title="Receiver Operating Characteristic (ROC)",
-            subtitle=f"AUC: {roc_auc.round(2)}",
+            subtitle=f"AUC: {round(roc_auc, 2)}",
             x="False Positive Rate",
             y="True Positive Rate",
         )

--- a/model-scoring/requirements.txt
+++ b/model-scoring/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 pandas
 plotnine
-scikit-learn>=1.6.1
+scikit-learn>=1.7.0
 shiny

--- a/model-scoring/requirements.txt
+++ b/model-scoring/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 pandas
 plotnine
-scikit-learn
+scikit-learn==1.6.1
 shiny

--- a/model-scoring/requirements.txt
+++ b/model-scoring/requirements.txt
@@ -1,5 +1,5 @@
 numpy
 pandas
 plotnine
-scikit-learn==1.6.1
+scikit-learn>=1.6.1
 shiny


### PR DESCRIPTION
This pull request introduces updates to the deployment workflow, a minor code improvement in the ROC plot function, and a version update for a key dependency. Below is a summary of the most important changes:

* Added support for branches prefixed with `fix**` in the deployment workflow trigger.

* Updated the `plot_auc_curve` function to use the built-in `round` function for formatting the AUC subtitle, ensuring consistency and clarity.

* Updated the `scikit-learn` dependency to require version `1.7.0` or higher.