### PR TITLE
fix(nba-dashboard): Fix groupby apply in percentiles calculation

### DIFF
--- a/nba-dashboard/app-express.py
+++ b/nba-dashboard/app-express.py
@@ -102,13 +102,17 @@ def player_stats():
 @reactive.calc
 def percentiles():
     d = player_stats()
+    careers_data = careers()
 
     def apply_func(x):
+        result = x.copy()
         for col in stats:
-            x[col] = (x[col].values > careers()[col].values).mean()
-        return x
+            result[col] = (x[col].values > careers_data[col].values).mean()
+        return result
 
-    return d.groupby("person_id").apply(apply_func, include_groups=True)
+    result = d.groupby("person_id").apply(apply_func, include_groups=False)
+    result = result.reset_index()
+    return result
 
 
 # When a player is clicked on the rug plot, add them to the selected players


### PR DESCRIPTION
Updated the percentiles() function to use include_groups=False in groupby.apply and reset the index after applying the function. This ensures the output DataFrame has the correct structure and avoids issues with group labels in the result.