### PR TITLE
fix(nba-dashboard): Limit columns in percentiles groupby apply

### DIFF
--- a/nba-dashboard/app-express.py
+++ b/nba-dashboard/app-express.py
@@ -108,9 +108,9 @@ def percentiles():
             x[col] = (x[col].values > careers()[col].values).mean()
         return x
 
-    return d.groupby("person_id")[
-        ["person_id", "player_name", "color", *stats]
-    ].apply(apply_func, include_groups=False)
+    return d.groupby("person_id")[["person_id", "player_name", "color", *stats]].apply(
+        apply_func, include_groups=False
+    )
 
 
 # When a player is clicked on the rug plot, add them to the selected players

--- a/nba-dashboard/app-express.py
+++ b/nba-dashboard/app-express.py
@@ -108,7 +108,9 @@ def percentiles():
             x[col] = (x[col].values > careers()[col].values).mean()
         return x
 
-    return d.groupby("person_id").apply(apply_func, include_groups=False)
+    return d.groupby("person_id")[
+        ["person_id", "player_name", "color", *stats]
+    ].apply(apply_func, include_groups=False)
 
 
 # When a player is clicked on the rug plot, add them to the selected players


### PR DESCRIPTION
The percentiles function now selects only relevant columns before applying the groupby operation, reducing unnecessary data processing and potential errors.

Mimics the core syntax of this dashboard