### PR TITLE
Standardize app IDs in template JSON files

### DIFF
--- a/gen-ai/interactive-chat-explorer/langchain-basic/_template.json
+++ b/gen-ai/interactive-chat-explorer/langchain-basic/_template.json
@@ -1,6 +1,6 @@
 {
   "type": "app",
-  "id": "langchain-basic-chat",
+  "id": "langchain-basic",
   "title": "A Chat app leveraging LangChain framework",
   "description": "This app allows users to interact with a language model using the LangChain framework.",
   "next_steps": [

--- a/gen-ai/interactive-chat-explorer/langchain-structured-output/_template.json
+++ b/gen-ai/interactive-chat-explorer/langchain-structured-output/_template.json
@@ -1,6 +1,6 @@
 {
   "type": "app",
-  "id": "langchain-structured-output-chat",
+  "id": "langchain-structured-output",
   "title": "LangChain Chat with Structured Output",
   "description": "Shows how to constrain model responses to a structured schema using LangChain (e.g., pydantic or JSON mode).",
   "next_steps": [

--- a/gen-ai/interactive-chat-explorer/langchain-tool-calling/_template.json
+++ b/gen-ai/interactive-chat-explorer/langchain-tool-calling/_template.json
@@ -1,6 +1,6 @@
 {
   "type": "app",
-  "id": "langchain-tool-calling-chat",
+  "id": "langchain-tool-calling",
   "title": "LangChain Chat with Tool Calling",
   "description": "Demonstrates using LangChain to enable the model to select and invoke tools/functions during a chat session.",
   "next_steps": [

--- a/gen-ai/interactive-chat-explorer/llama-index-basic/_template.json
+++ b/gen-ai/interactive-chat-explorer/llama-index-basic/_template.json
@@ -1,6 +1,6 @@
 {
   "type": "app",
-  "id": "llama-index-basic-chat",
+  "id": "llama-index-basic",
   "title": "Basic Chat with LlamaIndex",
   "description": "Minimal LlamaIndex-powered chat demonstrating a direct LLM conversation loop.",
   "next_steps": [

--- a/gen-ai/interactive-chat-explorer/llama-index-structured-output/_template.json
+++ b/gen-ai/interactive-chat-explorer/llama-index-structured-output/_template.json
@@ -1,6 +1,6 @@
 {
   "type": "app",
-  "id": "llama-index-structured-output-chat",
+  "id": "llama-index-structured-output",
   "title": "Structured Output with LlamaIndex",
   "description": "Chat example producing structured (JSON / schema) responses using LlamaIndex tools.",
   "next_steps": [

--- a/gen-ai/interactive-chat-explorer/llama-index-tool-calling/_template.json
+++ b/gen-ai/interactive-chat-explorer/llama-index-tool-calling/_template.json
@@ -1,6 +1,6 @@
 {
   "type": "app",
-  "id": "llama-index-tool-calling-chat",
+  "id": "llama-index-tool-calling",
   "title": "Tool Calling with LlamaIndex",
   "description": "Demonstrates model-invoked tool (function) calls orchestrated by LlamaIndex.",
   "next_steps": [

--- a/gen-ai/interactive-chat-explorer/llm-package-basic/_template.json
+++ b/gen-ai/interactive-chat-explorer/llm-package-basic/_template.json
@@ -1,8 +1,8 @@
 {
   "type": "app",
-  "id": "llm-package-basic-chat",
-  "title": "Basic Chat using llm_package",
-  "description": "Simple chat illustrating a direct conversation loop with llm_package abstractions.",
+  "id": "llm-package-basic",
+  "title": "Basic Chat using llm package",
+  "description": "Simple chat illustrating a direct conversation loop with llm package abstractions.",
   "next_steps": [
     "Add your API key(s) into template.env and rename it to .env.",
     "Run the app with shiny run app-express.py."

--- a/gen-ai/interactive-chat-explorer/llm-package-structured-output/_template.json
+++ b/gen-ai/interactive-chat-explorer/llm-package-structured-output/_template.json
@@ -1,8 +1,8 @@
 {
   "type": "app",
-  "id": "llm-package-structured-output-chat",
-  "title": "Structured Output with llm_package",
-  "description": "Shows enforcing structured schema in responses using llm_package utilities.",
+  "id": "llm-package-structured-output",
+  "title": "Structured Output with llm package",
+  "description": "Shows enforcing structured schema in responses using llm package utilities.",
   "next_steps": [
     "Add your API key(s) into template.env and rename it to .env.",
     "Run the app with shiny run app-express.py."

--- a/gen-ai/interactive-chat-explorer/llm-package-tool-calling/_template.json
+++ b/gen-ai/interactive-chat-explorer/llm-package-tool-calling/_template.json
@@ -1,8 +1,8 @@
 {
   "type": "app",
-  "id": "llm-package-tool-calling-chat",
-  "title": "Tool Calling with llm_package",
-  "description": "Demonstrates dispatching tool/function calls via llm_package orchestration.",
+  "id": "llm-package-tool-calling",
+  "title": "Tool Calling with llm package",
+  "description": "Demonstrates dispatching tool/function calls via llm package orchestration.",
   "next_steps": [
     "Add your API key(s) into template.env and rename it to .env.",
     "Run the app with shiny run app-express.py."

--- a/gen-ai/interactive-chat-explorer/pydantic-ai-basic/_template.json
+++ b/gen-ai/interactive-chat-explorer/pydantic-ai-basic/_template.json
@@ -1,6 +1,6 @@
 {
   "type": "app",
-  "id": "pydantic-ai-basic-chat",
+  "id": "pydantic-ai-basic",
   "title": "Basic Chat with Pydantic-AI",
   "description": "Simple chat using Pydantic models for validated inputs/outputs.",
   "next_steps": [

--- a/gen-ai/interactive-chat-explorer/pydantic-ai-structured-output/_template.json
+++ b/gen-ai/interactive-chat-explorer/pydantic-ai-structured-output/_template.json
@@ -1,6 +1,6 @@
 {
   "type": "app",
-  "id": "pydantic-ai-structured-output-chat",
+  "id": "pydantic-ai-structured-output",
   "title": "Structured Output with Pydantic-AI",
   "description": "Uses Pydantic models to shape and validate structured responses from the model.",
   "next_steps": [

--- a/gen-ai/interactive-chat-explorer/pydantic-ai-tool-calling/_template.json
+++ b/gen-ai/interactive-chat-explorer/pydantic-ai-tool-calling/_template.json
@@ -1,6 +1,6 @@
 {
   "type": "app",
-  "id": "pydantic-ai-tool-calling-chat",
+  "id": "pydantic-ai-tool-calling",
   "title": "Tool Calling with Pydantic-AI",
   "description": "Demonstrates invoking and validating tool calls with Pydantic-AI patterns.",
   "next_steps": [


### PR DESCRIPTION
Updated the 'id' fields in all _template.json files under gen-ai/interactive-chat-explorer to remove '-chat' suffixes and ensure consistent naming across all app templates. Also updated some descriptions for consistency with package naming.