### PR TITLE
fix(monitor-database): use asyncio.get_running_loop() (Python 3.14 compat)

### DIFF
--- a/monitor-database/scoredata.py
+++ b/monitor-database/scoredata.py
@@ -63,9 +63,14 @@ def begin():
     # need to launch a background thread and run an asyncio event loop there. (This is
     # the case when running via shinyapps.io or Posit Connect.)
 
-    if asyncio.get_event_loop().is_running():
-        asyncio.create_task(update_db(position))
-    else:
+    # Use `asyncio.get_running_loop()` (raises if no loop is running) rather than
+    # `asyncio.get_event_loop()`: the latter's auto-create behavior is deprecated in
+    # Python 3.12 and removed in 3.14, where it raises a RuntimeError instead.
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
         from threading import Thread
 
         Thread(target=lambda: asyncio.run(update_db(position)), daemon=True).start()
+    else:
+        asyncio.create_task(update_db(position))


### PR DESCRIPTION
## Summary

- `asyncio.get_event_loop()`'s auto-create-a-loop behavior was deprecated in Python 3.12 and removed in 3.14, where it raises `RuntimeError: There is no current event loop in thread 'MainThread'`. The monitor-database template's `scoredata.begin()` is called at app import time with no running loop, so on 3.14 the template no longer starts.
- Replace the `get_event_loop().is_running()` check with a `get_running_loop()` try/except. Identical fix as the one just landed in posit-dev/py-shiny#2244 for `examples/model-score/scoredata.py`.

## Why this matters now

posit-dev/py-shiny's playwright-examples CI checks out this repo at `main` and runs every template app. On Python 3.14 (now in the matrix) the monitor-database template fails to start, timing out the whole CI run.

## Test plan

- [ ] py-shiny's `tests/playwright/examples/test_external_templates.py::test_external_templates[chromium-py-shiny-templates/monitor-database/app-core.py]` passes once this is merged and the py-shiny CI re-runs against `main`.