### PR TITLE
refactor: Migrate render.download to render.download_button/link

### DIFF
--- a/gen-ai/dinner-recipe/app-core.py
+++ b/gen-ai/dinner-recipe/app-core.py
@@ -176,7 +176,7 @@ Want to save this recipe? Click the "Save recipe" button below.
             await stream.append("Cooking up a recipe for you!")
             await stream.replace(await recipe_message())
 
-    @render.download(filename="recipe.json")
+    @render.download_button(filename="recipe.json")
     async def download_handler():
         import json
 

--- a/gen-ai/dinner-recipe/app-express.py
+++ b/gen-ai/dinner-recipe/app-express.py
@@ -184,7 +184,7 @@ async def _():
 
 with ui.hold() as download_recipe:
 
-    @render.download(filename="recipe.json", label="Download recipe")
+    @render.download_button(filename="recipe.json", label="Download recipe")
     async def download_handler():
         import json
 

--- a/gen-ai/dinner-recipe/requirements.txt
+++ b/gen-ai/dinner-recipe/requirements.txt
@@ -1,5 +1,5 @@
 shinyswatch
-shiny
+shiny @ git+https://github.com/posit-dev/py-shiny.git@main  # TODO: release - revert to PyPI `shiny>=1.7.0` once 1.7.0 is published (py-shiny#2364)
 openai
 dotenv
 faicons

--- a/gen-ai/dinner-recipe/requirements.txt
+++ b/gen-ai/dinner-recipe/requirements.txt
@@ -1,5 +1,5 @@
 shinyswatch
-shiny @ git+https://github.com/posit-dev/py-shiny.git@main  # TODO: release - revert to PyPI `shiny>=1.7.0` once 1.7.0 is published (py-shiny#2364)
+shiny>=1.7.0
 openai
 dotenv
 faicons

--- a/gen-ai/workout-plan/app-core.py
+++ b/gen-ai/workout-plan/app-core.py
@@ -79,7 +79,7 @@ def server(input: Inputs):
         _ = workout_stream.latest_stream.result()
         return ui.download_button("download", "Download Workout")
 
-    @render.download(filename="workout_plan.md", label="Download Workout")
+    @render.download_button(filename="workout_plan.md", label="Download Workout")
     def download():
         yield workout_stream.latest_stream.result()
 

--- a/gen-ai/workout-plan/app-express.py
+++ b/gen-ai/workout-plan/app-express.py
@@ -44,7 +44,7 @@ with ui.sidebar(open={"mobile": "always-above"}):
     def download_ui():
         plan = workout_stream.latest_stream.result()
 
-        @render.download(filename="workout_plan.md", label="Download Workout")
+        @render.download_button(filename="workout_plan.md", label="Download Workout")
         def download():
             yield plan
 

--- a/gen-ai/workout-plan/requirements.txt
+++ b/gen-ai/workout-plan/requirements.txt
@@ -1,4 +1,4 @@
-shiny @ git+https://github.com/posit-dev/py-shiny.git@main  # TODO: release - revert to PyPI `shiny>=1.7.0` once 1.7.0 is published (py-shiny#2364)
+shiny>=1.7.0
 dotenv
 faicons
 chatlas[anthropic]

--- a/gen-ai/workout-plan/requirements.txt
+++ b/gen-ai/workout-plan/requirements.txt
@@ -1,4 +1,4 @@
-shiny
+shiny @ git+https://github.com/posit-dev/py-shiny.git@main  # TODO: release - revert to PyPI `shiny>=1.7.0` once 1.7.0 is published (py-shiny#2364)
 dotenv
 faicons
 chatlas[anthropic]

--- a/monitor-folder/app-core.py
+++ b/monitor-folder/app-core.py
@@ -73,7 +73,7 @@ def server(input: Inputs, output: Outputs, session: Session):
         id = random.randint(100, 999)
         sampled_logs.to_csv(watch_folder / f"logs-{id}.csv")
 
-    @render.download(filename="logs.csv")
+    @render.download_link(filename="logs.csv")
     def download():
         csv = selected_file()
         with io.StringIO() as buf:

--- a/monitor-folder/app-express.py
+++ b/monitor-folder/app-express.py
@@ -36,7 +36,7 @@ with ui.layout_columns(col_widths=[4, 8]):
                 ):
                     "Log output"
 
-                    @render.download(filename="logs.csv")
+                    @render.download_link(filename="logs.csv")
                     def download():
                         csv = selected_file()
                         with io.StringIO() as buf:

--- a/monitor-folder/requirements.txt
+++ b/monitor-folder/requirements.txt
@@ -1,4 +1,4 @@
-shiny 
+shiny @ git+https://github.com/posit-dev/py-shiny.git@main  # TODO: release - revert to PyPI `shiny>=1.7.0` once 1.7.0 is published (py-shiny#2364)
 pandas
 faicons
 watchfiles

--- a/monitor-folder/requirements.txt
+++ b/monitor-folder/requirements.txt
@@ -1,4 +1,4 @@
-shiny @ git+https://github.com/posit-dev/py-shiny.git@main  # TODO: release - revert to PyPI `shiny>=1.7.0` once 1.7.0 is published (py-shiny#2364)
+shiny>=1.7.0
 pandas
 faicons
 watchfiles


### PR DESCRIPTION
> [!WARNING]
> **TODO — do not merge yet:** These apps run against the released `shiny` from PyPI. `@render.download_button` / `@render.download_link` are only available once the py-shiny release containing [posit-dev/py-shiny#2364](https://github.com/posit-dev/py-shiny/pull/2364) is published to PyPI. **Wait for that release before merging**, otherwise these templates will break on the current released `shiny`.
>
> - [ ] py-shiny release with `render.download_button`/`render.download_link` published to PyPI

## Summary

`@render.download` was deprecated in py-shiny in favor of `@render.download_button` and `@render.download_link`, which pair 1:1 with `ui.download_button()` / `ui.download_link()` respectively (see [posit-dev/py-shiny#2364](https://github.com/posit-dev/py-shiny/pull/2364)). The py-shiny `playwright-examples` CI job clones this repo and runs its apps, treating the new `ShinyDeprecationWarning: render.download is deprecated...` as a failure. This PR migrates all `render.download` usages so that job stays green.

Only the decorator token was changed (`render.download` -> `render.download_button` or `render.download_link`); all arguments (`filename=`, `label=`, etc.) are unchanged, and no UI-side `ui.download_button`/`ui.download_link` calls were touched.

## Files migrated

- `gen-ai/dinner-recipe/app-core.py` -> `render.download_button` (paired with explicit `ui.download_button(...)`)
- `gen-ai/dinner-recipe/app-express.py` -> `render.download_button` (Express auto-placement, matches core app's button)
- `gen-ai/workout-plan/app-core.py` -> `render.download_button` (paired with explicit `ui.download_button(...)`)
- `gen-ai/workout-plan/app-express.py` -> `render.download_button` (Express auto-placement, matches core app's button)
- `monitor-folder/app-core.py` -> `render.download_link` (paired with explicit `ui.download_link(...)`)
- `monitor-folder/app-express.py` -> `render.download_link` (Express auto-placement, mirrors the core app's `ui.download_link` design)

## Test plan

- [x] Verified no remaining `render.download` (bare) usages via `grep -rn "render\.download\b\|render\.download(" .`
- [x] `ast.parse()` succeeds on all edited files
- [ ] CI / manual run of each migrated app to confirm no deprecation warnings

## TODO — after merge
- [ ] **Remove the temporary py-shiny CI pin to this branch.** py-shiny's `.github/workflows/pytest.yaml` currently checks out this repo at `ref: migrate-render-download-button` (marked `TODO: release`) so its `playwright-examples` job stays green while `render.download` is deprecated. Once this PR is merged to the default branch, that `ref:` must be removed so py-shiny CI tracks the default branch again.


---
### TODO update (py-shiny#2364 merged to `main` 2026-07-22)
- [x] `render.download_button`/`render.download_link` merged to py-shiny `main` (#2364).
- [x] Point the 3 migrated apps' `requirements.txt` `shiny` at py-shiny `main` so they can run the new API before 1.7.0 is on PyPI (`gen-ai/dinner-recipe`, `gen-ai/workout-plan`, `monitor-folder`; each marked `TODO: release`).
- [ ] **At release:** revert those `requirements.txt` back to the PyPI pin (`shiny>=1.7.0`) once 1.7.0 is published, then merge.
- [ ] **After merge:** remove py-shiny's temporary CI pin to this branch (`.github/workflows/pytest.yaml` `ref: migrate-render-download-button`, marked `TODO: release`).
